### PR TITLE
use a unique bucket for s3 tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 pdf-renderer.iml
 debug
 pdf-renderer
+pdf-renderer_darwin_amd64
 pdf-renderer_linux_amd64
 .idea

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ GOCLEAN=$(GOCMD) clean
 GOTEST=$(GOCMD) test
 GOGET=$(GOCMD) get
 BINARY_NAME=pdf-renderer
-BINARY_LINUX=$(BINARY_NAME)_linux_amd64
 
 all: test build
 build:
@@ -20,5 +19,8 @@ run:
 	$(GOBUILD) -o $(BINARY_NAME) -v ./...
 	./$(BINARY_NAME)
 
+build-darwin:
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GOBUILD) -o $(BINARY_NAME)_darwin_amd64 -v
+
 build-linux:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) -o $(BINARY_LINUX) -v
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) -o $(BINARY_NAME)_linux_amd64 -v

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # PDF-RENDERER
-
 This service runs in conjunction with a headless chrome browser. It listens for requests on port 9766. Upon receiving a render request, it will go to a URL, render the page and respond with a zip file. The zip file will contain a json file and a pdf file. The json file will be a list of network requests made by the page that was rendered. The pdf file will be a print-out of the page. 
 
 ## Features:
@@ -57,7 +56,7 @@ Description: defines the number of times to poll the browser for new network req
 
 #### PDF_RENDERER_S3_BUCKET 
 Default Value: **NOT SET**  
-Description: defines the bucket in which the zip is stored if storage strategy is set to 's3'. Note: This must be a globally unique name.
+Description: defines the bucket in which the zip is stored if storage strategy is set to 's3'. To be non-invasive, this service will not create the bucket for you.
 
 #### PDF_RENDERER_REQUEST_POLL_INTERVAL
 Default Value: (time.Duration) `1s`  
@@ -68,6 +67,22 @@ Default Value: (time.Duration) `5m`
 Description: defines the maximum amount of time to spend on any given render request before simply printing whatever is there 
 
 ## Usage
+
+#### Getting Started
+Please be advised that running make will also run the unit tests. The unit tests require an AWS account with credentials and config in order to test the s3 storage strategy. Please refer to https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html in order to properly configure your environment.
+
+With unit tests:
+```
+make run
+```
+
+Without unit tests:
+```
+go build
+./pdf-renderer
+```
+
+#### Example request:
 ```
 cd $GOPATH
 go get github.com/rapid7/pdf-renderer
@@ -118,11 +133,10 @@ The json file structured as such:
 * Please be cautious with the potential values for target url and the potential recipients of the response. If the value of the targetUrl is a sensitive url, sensitive data could be exposed. For example, setting it to 169.254.169.254 (aws meta-data service) could expose information that you might not want exposed.
 
 ## TODO
-* create a unique bucket for s3 tests and delete it afterwards (blocker for next release)
 * add support for other headless browsers
 * make the QoS more robust (request method, time to generate, etc)
 * blacklist for targetUrl values
 * enable/disable for various features
 * add a way to return only the json (correlation is problematic here)
 * use the ec2 metadata service to resolve the region
-
+* make it so the unit tests don't require you to have an aws account (skip aws tests if not configured?)

--- a/cfg/environment.go
+++ b/cfg/environment.go
@@ -8,20 +8,7 @@ import (
 	"os"
 	"strconv"
 	"time"
-
-	log "github.com/sirupsen/logrus"
 )
-
-func init() {
-	// Ensure env var "PDF_RENDERER_S3_BUCKET" is set
-	strategy := Config().StorageStrategy()
-	if strategy == "s3" {
-		s := Config().S3Bucket()
-		if len(s) == 0 {
-			log.Fatal("Environment variable PDF_RENDERER_S3_BUCKET must be set.")
-		}
-	}
-}
 
 type envConfig struct {
 }

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/rapid7/pdf-renderer
 
 require (
 	github.com/aws/aws-sdk-go v1.16.26
+	github.com/google/uuid v1.1.0
 	github.com/gorilla/mux v1.7.0
 	github.com/gorilla/websocket v1.4.0 // indirect
 	github.com/mafredri/cdp v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/aws/aws-sdk-go v1.16.26 h1:GWkl3rkRO/JGRTWoLLIqwf7AWC4/W/1hMOUZqmX0js4=
 github.com/aws/aws-sdk-go v1.16.26/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.1.0 h1:Jf4mxPC/ziBnoPIdpQdPJ9OeiomAUHLvxmPRSPH9m4s=
+github.com/google/uuid v1.1.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.7.0 h1:tOSd0UKHQd6urX6ApfOn4XdBMY6Sh1MfxV3kmaazO+U=
 github.com/gorilla/mux v1.7.0/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=

--- a/main.go
+++ b/main.go
@@ -22,6 +22,15 @@ func init() {
 		log.SetLevel(log.DebugLevel)
 		go periodicallyLogMemUsage()
 	}
+
+	// Ensure env var "PDF_RENDERER_S3_BUCKET" is set
+	strategy := cfg.Config().StorageStrategy()
+	if strategy == "s3" {
+		s := cfg.Config().S3Bucket()
+		if len(s) == 0 {
+			log.Fatal("Environment variable PDF_RENDERER_S3_BUCKET must be set.")
+		}
+	}
 }
 
 func periodicallyLogMemUsage() {

--- a/storage/s3__test.go
+++ b/storage/s3__test.go
@@ -3,20 +3,50 @@ package storage
 import (
 	"fmt"
 	"testing"
+	"os"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/google/uuid"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 )
 
 const TestObjectContent = "Some Test Content"
 
-func TestNewS3Client(t *testing.T) {
-	_, err := newS3Client()
-	if err != nil {
-		fmt.Println(err)
-		t.Fail()
+var bucketName, uuidErr = uuid.NewRandom()
+
+func TestMain(m *testing.M) {
+	sess := createAwsSession()
+	svc := s3.New(sess)
+
+	createBucketInput := &s3.CreateBucketInput{
+		Bucket: aws.String(bucketName.String()),
 	}
+
+	_, err := svc.CreateBucket(createBucketInput)
+	if err != nil {
+		fmt.Println(err.Error())
+	}
+
+	newS3Client(sess, bucketName.String())
+	code := m.Run()
+
+	deleteBucketInput := &s3.DeleteBucketInput{
+		Bucket: aws.String(bucketName.String()),
+	}
+
+	_, err = svc.DeleteBucket(deleteBucketInput)
+	if err != nil {
+		fmt.Println(err.Error())
+	}
+
+	os.Exit(code)
 }
 
 func TestNewS3Object(t *testing.T) {
-	o, err := NewS3Object("someFile.zip")
+	fileName := randomFileName()
+
+	o, err := NewS3Object(fileName)
 	if err != nil {
 		fmt.Println(err)
 		t.Fail()
@@ -38,10 +68,14 @@ func TestNewS3Object(t *testing.T) {
 		t.Errorf("Expected object to be '%s', was '%s'", TestObjectContent, string(buf))
 		t.Fail()
 	}
+
+	deleteS3Object(&fileName)
 }
 
 func TestS3Object_Exists(t *testing.T) {
-	o, err := NewS3Object("TestFile.zip")
+	fileName := randomFileName()
+
+	o, err := NewS3Object(fileName)
 	if err != nil {
 		fmt.Println(err)
 		t.Fail()
@@ -56,10 +90,14 @@ func TestS3Object_Exists(t *testing.T) {
 	if exists := o.Exists(); !exists {
 		t.Errorf("Expected TestFile.zip to exist")
 	}
+
+	deleteS3Object(&fileName)
 }
 
 func TestS3Object_Overridable(t *testing.T) {
-	o, err := NewS3Object("TestFile.zip")
+	fileName := randomFileName()
+
+	o, err := NewS3Object(fileName)
 	if err != nil {
 		fmt.Println(err)
 		t.Fail()
@@ -101,4 +139,26 @@ func TestS3Object_Overridable(t *testing.T) {
 		t.Fail()
 	}
 
+	deleteS3Object(&fileName)
+}
+
+func createAwsSession() *session.Session {
+	return session.Must(session.NewSessionWithOptions(session.Options{
+		Config: *aws.NewConfig().WithRegion(endpoints.UsEast1RegionID),
+		SharedConfigState: session.SharedConfigEnable,
+	}))
+}
+
+func randomFileName() string {
+	randomUuid, _ := uuid.NewRandom()
+
+	return randomUuid.String() + ".zip"
+}
+
+func deleteS3Object(fileName *string) {
+	deleteObjectInput := &s3.DeleteObjectInput{
+		Bucket: aws.String(bucketName.String()),
+		Key: fileName,
+	}
+	getS3Client().client.DeleteObject(deleteObjectInput)
 }


### PR DESCRIPTION
* don't create the bucket in s3 mode
* made it easier to test
* removed some unnecessary error handling
* updated readme
* updated makefile

@mdanzinger For your reference. I made some changes related to the s3 stuff. Basically made it less invasive and made it so the unit tests clean up after themselves.