### PR TITLE
Trim filesystem paths from builds (Makefile)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GOCMD=go
-GOBUILD=$(GOCMD) build
+GOBUILD=$(GOCMD) build -trimpath
 GOCLEAN=$(GOCMD) clean
 GOTEST=$(GOCMD) test
 GOGET=$(GOCMD) get


### PR DESCRIPTION
Use `-trimpath` on builds, removes filesystem paths from builds so stacktraces do not contain user-local filesystem paths. 